### PR TITLE
fix enter key handling

### DIFF
--- a/src/datepicker.jsx
+++ b/src/datepicker.jsx
@@ -153,7 +153,9 @@ var DatePicker = React.createClass({
     if (event.key === 'Enter' || event.key === 'Escape') {
       event.preventDefault()
       this.setOpen(false)
-      this.setSelectedDateByKey(event.key)
+      if (this.props.isKeyHandlable) {
+        this.setSelectedDateByKey(event.key)
+      }
     } else if (event.key === 'Tab') {
       this.setOpen(false)
     } else if (this.props.isKeyHandlable) {


### PR DESCRIPTION
Key down of enter event is fired for syncing selected value on calendar even though key handling is disabled.
If key handling is disabled, to be not fired it.
